### PR TITLE
Optionally disable stories

### DIFF
--- a/patches/FeurHooks.smali
+++ b/patches/FeurHooks.smali
@@ -75,6 +75,13 @@
     move-result v2
     if-nez v2, :cond_block
 
+
+    # Optionally block Stories
+    #const-string v1, "/feed/reels_tray"
+    #invoke-virtual {v0, v1}, Ljava/lang/String;->contains(Ljava/lang/CharSequence;)Z
+    #move-result v2
+    #if-nez v2, :cond_block
+
     # Block explore content
     const-string v1, "/discover/topical_explore"
     invoke-virtual {v0, v1}, Ljava/lang/String;->contains(Ljava/lang/CharSequence;)Z


### PR DESCRIPTION
I have added a few (commented out lines) to optionally disable stories for users who don't want them shown in their feed. This does not have to be on by default but for users that want this. This can be an option in a future "options" menu where users would choose what to disable.