### PR TITLE
Hide like/repost bubbles

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -156,6 +156,7 @@ combination.
 | **Suggested accounts** | Blocked | Yes | Network-level + feed-parse blocking |
 | **Instants (+ button in DMs)** | Blocked | Yes | View visibility hidden |
 | **Notes (text bubbles above DMs)** | Blocked | Yes | View visibility hidden |
+| **Bubbles (friend like/repost)** | Visible | Yes | UI-model factory hooks |
 | **Ads** | Blocked | Yes | Network-level + feed-parse blocking |
 | **Analytics & telemetry** | Blocked | No | Always blocked |
 | **Shopping / commerce preloads** | Blocked | No | Always blocked |
@@ -183,7 +184,9 @@ of just the accounts you follow, with the recommended/ranked posts dropped.
 main tab bar). A full-screen, scrollable settings page opens with:
 
 - **Blocked surfaces** — toggles for Home Feed, Explore, Reels, Stories,
-  Suggested accounts, Ads, Instants, and Notes.
+  Suggested accounts, Ads, Instants, Notes, and Bubbles (the floating friend
+  like/repost avatar bubbles overlaid on reels, feed posts and the saved-reels
+  grid).
 - **Feed** — *Following feed only*: restrict the Home Feed to accounts you
   follow (chronological), instead of the recommended feed. Has effect only when
   the Home Feed is left unblocked.

--- a/extensions/extension/src/main/java/com/feurstagram/extension/Config.java
+++ b/extensions/extension/src/main/java/com/feurstagram/extension/Config.java
@@ -104,6 +104,41 @@ public final class Config {
     public static boolean isNotesBlocked()     { return getBlocked("block_notes", true); }
     public static boolean isSuggestedBlocked() { return getBlocked("block_suggested", true); }
     public static boolean isAdsBlocked()       { return getBlocked("block_ads", true); }
+    public static boolean isBubblesBlocked()   { return getBlocked("block_bubbles", false); }
+
+    /**
+     * Cached toggle read for the bytecode-patched bubble hooks. Those hooks fire on
+     * hot paths (per feed item / reel gate), so we avoid a SharedPreferences +
+     * reflection lookup on every call. Toggling any block goes through a full app
+     * restart (see the settings page), so the value is constant for a process
+     * lifetime and safe to cache once the app Context exists.
+     */
+    private static Boolean sBubblesCache;
+
+    /** True when the friend like/repost bubbles should be hidden (Bubbles toggle). */
+    public static boolean hideBubblesCached() {
+        Boolean value = sBubblesCache;
+        if (value != null) return value;
+        if (getAppContext() == null) return false; // too early; don't cache yet
+        boolean resolved = isBubblesBlocked();
+        sBubblesCache = resolved;
+        return resolved;
+    }
+
+    // ---- Return-value filters used by the "Hide bubbles" bytecode patch ----
+    // The patch routes a hooked method's return value through one of these, which
+    // is verify-safe (it never clobbers the method's own registers). Each returns
+    // the original value untouched unless the Bubbles toggle is on.
+
+    /** Bubble show-gate (reels FriendlyViewer): force off when Bubbles is on. */
+    public static boolean applyBubbleGate(boolean original) {
+        return hideBubblesCached() ? false : original;
+    }
+
+    /** Bubble UI-state factory (feed/grid like & repost): null it when Bubbles is on. */
+    public static Object applyBubbleObject(Object original) {
+        return hideBubblesCached() ? null : original;
+    }
 
     /**
      * Whether the notifications ("heart") button in the feed header is hidden.
@@ -133,6 +168,7 @@ public final class Config {
         baseline.put("block_notes", isNotesBlocked());
         baseline.put("block_suggested", isSuggestedBlocked());
         baseline.put("block_ads", isAdsBlocked());
+        baseline.put("block_bubbles", isBubblesBlocked());
         sBaseline = baseline;
     }
 

--- a/extensions/extension/src/main/java/com/feurstagram/extension/Settings.java
+++ b/extensions/extension/src/main/java/com/feurstagram/extension/Settings.java
@@ -151,6 +151,7 @@ public final class Settings {
         addRow(context, surfaces, "Notes", "block_notes", Config.isNotesBlocked());
         addRow(context, surfaces, "Suggested accounts", "block_suggested", Config.isSuggestedBlocked());
         addRow(context, surfaces, "Ads", "block_ads", Config.isAdsBlocked());
+        addRow(context, surfaces, "Bubbles", "block_bubbles", Config.isBubblesBlocked());
         addRow(context, surfaces, "Notifications button", "block_notifications", Config.isNotificationsButtonBlocked());
 
         addSectionHeader(context, column, "NAVIGATION BAR");
@@ -443,6 +444,8 @@ public final class Settings {
             sub.setText("Check GitHub for a new version on launch.");
         } else if (key.equals("block_ads")) {
             sub.setText("Block sponsored ads across Instagram.");
+        } else if (key.equals("block_bubbles")) {
+            sub.setText("Hide the floating friend like/repost bubbles on reels, feed and grid.");
         } else if (key.equals("limit_following_feed")) {
             sub.setText("Show only accounts you follow (needs the feed unblocked).");
         } else if (key.equals("block_notifications")) {

--- a/patches/src/main/kotlin/com/feurstagram/patches/bubbles/HideBubblesPatch.kt
+++ b/patches/src/main/kotlin/com/feurstagram/patches/bubbles/HideBubblesPatch.kt
@@ -1,0 +1,115 @@
+package com.feurstagram.patches.bubbles
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import app.morphe.util.findMutableMethodOf
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.feurstagram.patches.shared.Constants.COMPATIBILITY_INSTAGRAM
+import com.feurstagram.patches.shared.Constants.EXTENSION
+
+// Removes Instagram's floating friend "bubbles" — the profile-avatar circles with a
+// heart (like) or reshare (repost) badge that overlay reels, feed posts and the
+// saved-reels grid ("people you follow engaged with this"). Gated on the Bubbles
+// runtime toggle.
+//
+// The bubbles are Litho-drawn from native Pando-tree data, so there is nothing to
+// hide at the view layer and nothing hookable at the data-read layer. Instead we
+// neutralise the code that BUILDS the bubble UI models:
+//
+//   1. Reels: force the FriendlyViewerExperimentUtil boolean gates off. Each gate
+//      logs a stable QPL marker string, so it is version-robust to fingerprint on.
+//   2. Feed / saved-reels grid: null the factories that return
+//      ClipsFriendlyBubbleUiState / RepostThoughtBubbleUiState (the on-media bubble
+//      view is created from these). The factory CLASSES are obfuscated and change
+//      per Instagram build — refresh `bubbleFactoryClasses` from a fresh `am profile`
+//      method trace of a grid scroll on a new version (see BUBBLE_REMOVAL_DEVLOG.md).
+//      The UI-state TYPE names below are stable.
+//
+// Every hook routes the target method's RETURN VALUE through a Config helper (which
+// returns the original value unless the toggle is on) rather than a register-clobbering
+// prologue. Reusing the value's own register is verify-safe regardless of the method's
+// register layout — an entry prologue that clobbered v0 failed ART verification on
+// methods where v0 holds a parameter.
+
+private const val CONFIG = "Lcom/feurstagram/extension/Config;"
+
+private fun friendlyViewerGate(name: String) =
+    "android_purge_26_q2_FriendlyViewerExperimentUtil_$name"
+
+internal object FriendlyViewerLikesFingerprint : Fingerprint(
+    strings = listOf(friendlyViewerGate("isFriendlyViewerLikesEnabled")),
+    returnType = "Z",
+)
+internal object FriendlyViewerFollowsFingerprint : Fingerprint(
+    strings = listOf(friendlyViewerGate("isFriendlyViewerFollowsEnabled")),
+    returnType = "Z",
+)
+internal object FriendlyViewerCommentsFingerprint : Fingerprint(
+    strings = listOf(friendlyViewerGate("isFriendlyViewerCommentsEnabled")),
+    returnType = "Z",
+)
+
+/**
+ * Inject `reg = <filter>(reg)` immediately before every matching return, reusing the
+ * return value's own register. Sites are collected first and rewritten from last to
+ * first so earlier indices stay valid as instructions are inserted.
+ */
+private fun MutableMethod.routeReturns(returnOpcode: Opcode, filterSmali: (reg: Int) -> String) {
+    val sites = instructions
+        .withIndex()
+        .filter { it.value.opcode == returnOpcode }
+        .map { it.index to (it.value as OneRegisterInstruction).registerA }
+    for ((index, register) in sites.sortedByDescending { it.first }) {
+        addInstructions(index, filterSmali(register))
+    }
+}
+
+@Suppress("unused")
+val hideBubblesPatch = bytecodePatch(
+    name = "Hide bubbles",
+    description = "Removes the floating friend like/repost bubbles on reels, feed posts and " +
+        "the saved-reels grid, gated on the Bubbles runtime toggle.",
+    default = true,
+) {
+    compatibleWith(COMPATIBILITY_INSTAGRAM)
+    extendWith(EXTENSION)
+
+    execute {
+        // 1) Reels friend like/follow/comment bubbles -> gate returns false when on.
+        for (fingerprint in listOf(
+            FriendlyViewerLikesFingerprint,
+            FriendlyViewerFollowsFingerprint,
+            FriendlyViewerCommentsFingerprint,
+        )) fingerprint.method.routeReturns(Opcode.RETURN) { reg ->
+            "invoke-static/range { v$reg .. v$reg }, $CONFIG->applyBubbleGate(Z)Z\n" +
+                "move-result v$reg"
+        }
+
+        // 2) Feed / saved-reels-grid friend & repost bubbles -> null the UI-state
+        //    factories so no bubble is built. Class names are obfuscated per build.
+        val bubbleFactoryClasses = listOf("LX/4mC;", "LX/6Tp;", "LX/3Mu;", "LX/815;")
+        val bubbleUiStateTypes = setOf(
+            "Lcom/instagram/friendlysystem/domain/uicontract/ClipsFriendlyBubbleUiState;",
+            "Lcom/instagram/friendlysystem/domain/uicontract/RepostThoughtBubbleUiState;",
+        )
+        for (className in bubbleFactoryClasses) {
+            val classDef = classDefByOrNull(className) ?: continue
+            val mutableClass = mutableClassDefBy(classDef)
+            for (method in classDef.methods) {
+                val bubbleType = method.returnType
+                if (bubbleType !in bubbleUiStateTypes) continue
+                if (method.implementation == null) continue
+                mutableClass.findMutableMethodOf(method).routeReturns(Opcode.RETURN_OBJECT) { reg ->
+                    "invoke-static/range { v$reg .. v$reg }, " +
+                        "$CONFIG->applyBubbleObject(Ljava/lang/Object;)Ljava/lang/Object;\n" +
+                        "move-result-object v$reg\n" +
+                        "check-cast v$reg, $bubbleType"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Hide friend like/repost bubbles

Adds a **Bubbles** toggle (Blocked surfaces) that removes Instagram's floating
friend-engagement bubbles — the avatar circles with a heart (like) or reshare
(repost) badge — overlaid on the reels viewer, feed posts, and the saved-reels grid.

## Why it isn't a view or network hook

The bubbles are **Litho-drawn from native Pando-tree data**, so:

- there is nothing to hide by resource id (no Android view),
- the social-context data is inline in `/feed/timeline/` (no separate request to block),
- the read-snapshot tree accessors (`com.facebook.pando.TreeJNI`) are all `native` (unhookable), and
- the named `com.instagram.feed.media.LiveTreeMediaDict` getters are never called by the render.

## How

It neutralises the code that **builds the bubble UI models**, gated on the toggle:

- **Reels** — force the `FriendlyViewerExperimentUtil` like/follow/comment gates to
  `false`. Each gate logs a stable QPL marker string, so it is fingerprinted on that
  (version-robust).
- **Feed / grid** — null the factory methods that return `ClipsFriendlyBubbleUiState`
  (like bubble) / `RepostThoughtBubbleUiState` (repost bubble), so no bubble is built.

Each hook routes the target method's **return value** through a `Config` helper
(gated on the toggle) rather than an entry prologue — reusing the value's own register
is verify-safe on any register layout.

## Notes

- Toggle defaults **off**; enable it via long-press Home → Blocked surfaces. The read
  is cached (a toggle change already restarts the app).
- The factory **classes are obfuscated per Instagram build**; the UI-state type names
  and the FriendlyViewer marker strings are stable. A maintenance note documents the
  method-trace procedure to refresh the class list on an Instagram update.
- Reference build: Instagram **436.0.0.41.73**.
- Tested on-device: bubbles gone on the reels viewer, feed posts, and the saved-reels
  grid; app stable.