### PR TITLE
Fix typo to capitalise h in "GitHub"

### DIFF
--- a/extensions/extension/src/main/java/com/feurstagram/extension/Settings.java
+++ b/extensions/extension/src/main/java/com/feurstagram/extension/Settings.java
@@ -194,7 +194,7 @@ public final class Settings {
         column.addView(checkUpdate, checkLp);
 
         // GitHub Sponsors: a calm, neutral button (not the flashy Sponsors pink).
-        Button sponsors = makeButton(context, "Donate on Github Sponsors", SURFACE_CONTAINER, ON_SURFACE, true);
+        Button sponsors = makeButton(context, "Donate on GitHub Sponsors", SURFACE_CONTAINER, ON_SURFACE, true);
         sponsors.setOnClickListener(v -> openUrl(context, "https://github.com/sponsors/jean-voila"));
         LinearLayout.LayoutParams sponsorsLp =
                 new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);


### PR DESCRIPTION
Replace "Github" with "GitHub". The h is capitalised everywhere else.
