### PR TITLE
Fix Done/Permanent lock buttons hidden behind 3-button nav bar

### DIFF
--- a/extensions/extension/src/main/java/com/feurstagram/extension/Settings.java
+++ b/extensions/extension/src/main/java/com/feurstagram/extension/Settings.java
@@ -18,6 +18,7 @@ import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
+import android.view.WindowInsets;
 import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.FrameLayout;
@@ -119,6 +120,11 @@ public final class Settings {
         int pad = dp(context, 24);
         int top = statusBarHeight(context) + dp(context, 24);
         root.setPadding(pad, top, pad, pad);
+        root.setOnApplyWindowInsetsListener((v, insets) -> {
+            int navInset = insets.getSystemWindowInsetBottom(); // real nav bar height, thin for gesture nav, tall for 3-button
+            v.setPadding(pad, top, pad, Math.max(pad, navInset)); // never shrink below the existing fixed padding
+            return insets;
+        });
 
         ScrollView scroll = new ScrollView(context);
         LinearLayout column = new LinearLayout(context);


### PR DESCRIPTION
Le padding bas du dialogue de settings était fixe (24dp), suffisant pour la nav gestuelle mais pas pour la barre à 3 boutons (~48dp), ce qui masquait partiellement les boutons Done et Permanent lock. Fix : lecture de l'inset réel de la nav bar via un OnApplyWindowInsetsListener, avec les 24dp existants comme plancher.